### PR TITLE
Implicit range

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,10 +50,14 @@ This will randomly combine two of the options for every batch, separated with a 
 
 	{1-3$$opt1|opt2|opt3}
 
-This will use a random number of options between 1 and 3 for each batch. 
+This will use a random number of options between 1 and 3 for each batch.
+
+	{-$$opt1|opt2|opt3}
+An omitted minimum is assumed to be 0 and an omitted maximum is assumed to be the number of options.
 
 	{opt1|opt2|opt3}
 If you omit the $$ prefix, one item will be selected. (Equivalent to 1$$)
+
 
 ### Wildcard files
 Wildcard files are not provided by this script as lists exists in other repositories. A good place to start looking is [here](https://github.com/jtkelm2/stable-diffusion-webui-1/tree/master/scripts/wildcards)

--- a/prompts/generators/randomprompt.py
+++ b/prompts/generators/randomprompt.py
@@ -34,15 +34,21 @@ class RandomPromptGenerator(PromptGenerator):
                 variants[0] = first_variant
                 
                 try:
-                    prefix_ints = [int(i) for i in prefix_num.split("-")]
-                    if len(prefix_ints) == 1:
-                        quantity = prefix_ints[0]
-                    elif len(prefix_ints) == 2:
-                        prefix_low = min(prefix_ints)
-                        prefix_high = max(prefix_ints)
+                    prefix_parts = prefix_num.split("-")
+                    if len(prefix_parts) == 1:
+                        quantity = int(prefix_parts[0])
+                    elif len(prefix_parts) == 2:
+                        if all(prefix_parts):
+                            prefix_ints = [int(i) for i in prefix_parts]
+                            prefix_low = min(prefix_ints)
+                            prefix_high = max(prefix_ints)
+                        else:
+                            prefix_low = int(prefix_parts[0]) if prefix_parts[0] else 0
+                            prefix_high = int(prefix_parts[1]) if prefix_parts[1] else len(variants)
+                        prefix_high = max(prefix_high, len(variants))
                         quantity = self._random.randint(prefix_low, prefix_high)
                     else:
-                        raise 
+                        raise
                 except Exception:
                     logger.warning(f"Unexpected combination formatting, expected $$ prefix to be a number or interval. Defaulting to {constants.DEFAULT_NUM_COMBINATIONS}")
             

--- a/scripts/dynamic_prompting.py
+++ b/scripts/dynamic_prompting.py
@@ -19,7 +19,7 @@ logger.setLevel(logging.INFO)
 base_dir = Path(scripts.basedir())
 
 WILDCARD_DIR = getattr(opts, "wildcard_dir", base_dir / "wildcards")
-VERSION = "0.13.6"
+VERSION = "0.13.7"
 
 
 wildcard_manager = WildcardManager(WILDCARD_DIR)


### PR DESCRIPTION
In ranges, an omitted lower bound becomes 0 and an omitted upper bound becomes the number of options.

`{-$$opt1|opt2|opt3}` is the same as `{0-3$$opt1|opt2|opt3}`.