### PR TITLE
Prevent 'pip' from launching every time the UI is started.

### DIFF
--- a/install.py
+++ b/install.py
@@ -1,4 +1,6 @@
 import launch
 
-launch.run_pip("install Jinja2==3.1.2", desc='Installing Jinja2==3.1.2')
-launch.run_pip("install requests==2.28.1", desc='Installing requests==2.28.1')
+if not launch.is_installed("jinja2"):
+    launch.run_pip("install Jinja2==3.1.2", desc='Installing Jinja2==3.1.2')
+if not launch.is_installed("requests"):
+    launch.run_pip("install requests==2.28.1", desc='Installing requests==2.28.1')


### PR DESCRIPTION
Is there a reason why we need to launch 'pip' on every start of UI?