### PR TITLE
add support for weighted variants

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 \.*.sw*
 .env
 wildcards
+.vscode

--- a/README.md
+++ b/README.md
@@ -85,6 +85,22 @@ Options are chosen randomly with replacement. This means that {2$$opt1|opt2} can
 
 This is useful in conjunction with wildcards (see below).
 
+Options can be assigned relative weights using a :: prefix operator.
+
+	photo of a {3::blue|red} ball
+
+This will generate 3 photos of a blue ball per every 1 photo of a red ball.
+
+	photo of a {blue|0.25::red} ball
+	
+Decimals also work as expected: this will generate 4 photos of a blue ball per every 1 photo of a red ball.
+
+	photo portrait of a {59::white|21::latino|14::black|8::asian} {man|woman}
+
+This would generate photo portraits of men and women of different races, proportional to the 2020 U.S. census.
+
+If you omit the :: prefix, it will have a default weight of 1.0. (Equivalent to 1::prompt)
+
 ### Wildcard files
 Wildcards are text files (ending in .txt). Each line contains a term, artist name, or modifier. The wildcard file can then be embedded in your prompt by removing the .txt extension and surrounding it with double underscores. e.g:
 

--- a/helptext.html
+++ b/helptext.html
@@ -13,6 +13,10 @@
     <code class="codeblock">{1-3$$$$artist1|artist2|artist3}</code><br/>
     In this case, a random number of artists between 1 and 3 is chosen.<br/><br/>
 
+    Options can be given weights:
+    <code class="codeblock">{2::artist1|artist2}</code><br/>
+    In this case, artist1 will be chosen twice as often as artist2.<br/><br/>
+
     Wildcards can be used and the joiner can also be specified:
     <code class="codeblock">{{1-$$$$and$$$$__adjective__}}</code><br/>
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,4 @@
+[tool.pytest.ini_options]
+pythonpath = [
+  "."
+]

--- a/tests/prompts/generators/test_combinationselector.py
+++ b/tests/prompts/generators/test_combinationselector.py
@@ -11,14 +11,14 @@ def wildcard_manager():
 class TestCombinationSelector:
     def test_rejects_empty(self, wildcard_manager):
         options = []
-        selector = CombinationSelector(wildcard_manager, options)
+        selector = CombinationSelector(wildcard_manager, options, [])
         
         selections = selector.pick()
         assert len(selections) == 0
 
     def test_selects_one(self, wildcard_manager):
         options = ["a"]
-        selector = CombinationSelector(wildcard_manager, options)
+        selector = CombinationSelector(wildcard_manager, options, [])
         
         selections = selector.pick()
         assert len(selections) == 1
@@ -26,75 +26,97 @@ class TestCombinationSelector:
 
     def test_selects_multiple(self, wildcard_manager):
         options = ["a", "b", "c", "d"]
-        selector = CombinationSelector(wildcard_manager, options)
+        selector = CombinationSelector(wildcard_manager, options, [])
 
-        with mock.patch("random.choice", side_effect=[
-            ["a"], "a",
-            ["b"], "b", 
-            ["a"], "a"
+        with mock.patch("random.choices", side_effect=[
+            ["a"],
+            ["b"],
+            ["a"]
         ]):
-            selections = selector.pick(3)
-            assert len(selections) == 3
-            assert selections[0] == "a"
-            assert selections[1] == "b"
-            assert selections[2] == "a"
+            with mock.patch("random.choice", side_effect=[
+                "a",
+                "b",
+                "a"
+            ]):
+                selections = selector.pick(3)
+                assert len(selections) == 3
+                assert selections[0] == "a"
+                assert selections[1] == "b"
+                assert selections[2] == "a"
 
     def test_selects_from_wildcard(self, wildcard_manager):
         options = ["__colours__"]
 
         colours = ["red", "green", "blue", "yellow"]
-        with mock.patch("random.choice", side_effect=[
-            colours, "red", 
-            colours, "yellow", 
-            colours, "blue"
+        with mock.patch("random.choices", side_effect=[
+            colours,
+            colours,
+            colours
         ]):
-            with mock.patch.object(wildcard_manager, "get_all_values", return_value=colours):
-                selector = CombinationSelector(wildcard_manager, options)
-                selections = selector.pick(3)
-                assert len(selections) == 3
-                assert selections[0] == "red"
-                assert selections[1] == "yellow"
-                assert selections[2] == "blue"
+            with mock.patch("random.choice", side_effect=[
+                "red",
+                "yellow",
+                "blue"
+            ]):
+                with mock.patch.object(wildcard_manager, "get_all_values", return_value=colours):
+                    selector = CombinationSelector(wildcard_manager, options, [])
+                    selections = selector.pick(3)
+                    assert len(selections) == 3
+                    assert selections[0] == "red"
+                    assert selections[1] == "yellow"
+                    assert selections[2] == "blue"
 
     def test_selects_from_wildcard_or_literal(self, wildcard_manager):
         options = ["__colours__", "a"]
 
         colours = ["red", "green", "blue", "yellow"]
-        with mock.patch("random.choice", side_effect=[
-            colours, "red", 
-            colours, "yellow", 
-            colours, "blue", 
-            ["a"], "a"
+        with mock.patch("random.choices", side_effect=[
+            colours,
+            colours,
+            colours,
+            ["a"]
         ]):
-            with mock.patch.object(wildcard_manager, "get_all_values", return_value=colours):
-                selector = CombinationSelector(wildcard_manager, options)
-                selections = selector.pick(4)
-                assert len(selections) == 4
-                assert selections[0] == "red"
-                assert selections[1] == "yellow"
-                assert selections[2] == "blue"
-                assert selections[3] == "a"
+            with mock.patch("random.choice", side_effect=[
+            "red",
+            "yellow",
+            "blue",
+            "a"
+            ]):
+                with mock.patch.object(wildcard_manager, "get_all_values", return_value=colours):
+                    selector = CombinationSelector(wildcard_manager, options, [])
+                    selections = selector.pick(4)
+                    assert len(selections) == 4
+                    assert selections[0] == "red"
+                    assert selections[1] == "yellow"
+                    assert selections[2] == "blue"
+                    assert selections[3] == "a"
 
     def test_selects_from_two_wildcards(self, wildcard_manager):
         options = ["__colours__", "__animals__"]
 
         colours = ["red", "green", "blue", "yellow"]
         animals = ["dog", "cat", "bird", "fish"]
-        with mock.patch("random.choice", side_effect=[
-            colours, "red", 
-            animals, "dog", 
-            colours, "blue", 
-            animals, "cat"
+        with mock.patch("random.choices", side_effects=[
+            colours,
+            animals,
+            colours,
+            animals
         ]):
-            with mock.patch.object(wildcard_manager, "get_all_values", side_effect=[
-                colours, animals
+            with mock.patch("random.choice", side_effect=[
+                "red",
+                "dog",
+                "blue",
+                "cat"
             ]):
-                selector = CombinationSelector(wildcard_manager, options)
-                selections = selector.pick(4)
-                assert len(selections) == 4
-                assert selections[0] == "red"
-                assert selections[1] == "dog"
-                assert selections[2] == "blue"
-                assert selections[3] == "cat"
+                with mock.patch.object(wildcard_manager, "get_all_values", side_effect=[
+                    colours, animals
+                ]):
+                    selector = CombinationSelector(wildcard_manager, options, [])
+                    selections = selector.pick(4)
+                    assert len(selections) == 4
+                    assert selections[0] == "red"
+                    assert selections[1] == "dog"
+                    assert selections[2] == "blue"
+                    assert selections[3] == "cat"
 
 

--- a/tests/prompts/generators/test_randomprompt.py
+++ b/tests/prompts/generators/test_randomprompt.py
@@ -37,10 +37,44 @@ class TestRandomPromptVariants:
         assert variant == "I love butter"
 
         variant = generator.pick_variant(template)
-        assert variant == "I love butter"
+        assert variant == "I love bread"
 
         variant = generator.pick_variant(template)
         assert variant == "I love butter"
+
+    def test_simple_pick_variant_weights(self, generator):
+        template = "I love {10::bread|butter}"
+        generator._template = template
+
+        variant = generator.pick_variant(template)
+        assert variant == 'I love bread'
+
+        variant = generator.pick_variant(template)
+        assert variant == 'I love bread'
+
+        variant = generator.pick_variant(template)
+        assert variant == 'I love butter'
+
+        variant = generator.pick_variant(template)
+        assert variant == 'I love bread'
+
+        variant = generator.pick_variant(template)
+        assert variant == 'I love bread'
+
+        variant = generator.pick_variant(template)
+        assert variant == 'I love butter'
+
+        variant = generator.pick_variant(template)
+        assert variant == 'I love bread'
+
+        variant = generator.pick_variant(template)
+        assert variant == 'I love bread'
+
+        variant = generator.pick_variant(template)
+        assert variant == 'I love bread'
+
+        variant = generator.pick_variant(template)
+        assert variant == 'I love bread'
 
     def test_multiple_pick_variant(self, generator):
         template = "I love {2$$bread|butter}"
@@ -50,10 +84,10 @@ class TestRandomPromptVariants:
         assert variant == "I love butter , bread"
 
         variant = generator.pick_variant(template)
-        assert variant == "I love bread , butter"
+        assert variant == "I love butter , bread"
 
         variant = generator.pick_variant(template)
-        assert variant == "I love bread , butter"
+        assert variant == "I love butter , bread"
 
     def test_multiple_variant_one_option(self, generator):
         template = "I love {2$$bread}"
@@ -77,16 +111,22 @@ class TestRandomPromptVariants:
         assert variant == "I love butter , bread"
 
         variant = generator.pick_variant(template)
-        assert variant == "I love bread , butter"
+        assert variant == "I love butter , bread"
+
+        variant = generator.pick_variant(template)
+        assert variant == "I love butter , bread"
 
         variant = generator.pick_variant(template)
         assert variant == "I love bread , butter"
 
         variant = generator.pick_variant(template)
-        assert variant == "I love butter"
+        assert variant == "I love bread , butter"
 
         variant = generator.pick_variant(template)
-        assert variant == "I love bread , butter"
+        assert variant == "I love butter , bread"
+
+        variant = generator.pick_variant(template)
+        assert variant == "I love bread"
 
     def test_variant_range_missing_lower(self, generator):
         template = "I love {-2$$bread|butter}"
@@ -96,19 +136,19 @@ class TestRandomPromptVariants:
         assert variant == "I love butter"
 
         variant = generator.pick_variant(template)
-        assert variant == "I love butter"
-
-        variant = generator.pick_variant(template)
-        assert variant == "I love butter"
-
-        variant = generator.pick_variant(template)
-        assert variant == "I love bread , butter"
-
-        variant = generator.pick_variant(template)
         assert variant == "I love "
 
         variant = generator.pick_variant(template)
-        assert variant == "I love butter , bread"
+        assert variant == "I love butter"
+
+        variant = generator.pick_variant(template)
+        assert variant == "I love butter"
+
+        variant = generator.pick_variant(template)
+        assert variant == "I love bread"
+
+        variant = generator.pick_variant(template)
+        assert variant == "I love bread , butter"
 
     def test_variant_range_missing_upper(self, generator):
         template = "I love {1-$$bread|butter}"
@@ -118,68 +158,100 @@ class TestRandomPromptVariants:
         assert variant == "I love butter , bread"
 
         variant = generator.pick_variant(template)
-        assert variant == "I love bread , butter"
+        assert variant == "I love butter , bread"
+
+        variant = generator.pick_variant(template)
+        assert variant == "I love butter , bread"
 
         variant = generator.pick_variant(template)
         assert variant == "I love bread , butter"
 
         variant = generator.pick_variant(template)
-        assert variant == "I love butter"
+        assert variant == "I love bread , butter"
+
+        variant = generator.pick_variant(template)
+        assert variant == "I love butter , bread"
+
+        variant = generator.pick_variant(template)
+        assert variant == "I love bread"
 
     def test_parse_combinations(self, generator):
-        quantity, _, options = generator._parse_combinations("bread|butter")
+        quantity, _, options, weights = generator._parse_combinations("bread|butter")
         assert quantity == (
             constants.DEFAULT_NUM_COMBINATIONS,
             constants.DEFAULT_NUM_COMBINATIONS,
         )
         assert options == ["bread", "butter"]
+        assert weights == [1.0, 1.0]
 
-        quantity, _, options = generator._parse_combinations("2$$bread|butter")
+        quantity, _, options, weights = generator._parse_combinations("2$$bread|butter")
         assert quantity == (2, 2)
         assert options == ["bread", "butter"]
+        assert weights == [1.0, 1.0]
 
-        quantity, _, options = generator._parse_combinations("1-2$$bread|butter")
+        quantity, _, options, weights = generator._parse_combinations("1-2$$bread|butter")
         assert quantity == (1, 2)
         assert options == ["bread", "butter"]
+        assert weights == [1.0, 1.0]
 
-        quantity, _, options = generator._parse_combinations("2-1$$bread|butter")
+        quantity, _, options, weights = generator._parse_combinations("2-1$$bread|butter")
         assert quantity == (1, 2)
         assert options == ["bread", "butter"]
+        assert weights == [1.0, 1.0]
 
-        quantity, _, options = generator._parse_combinations("1-$$bread|butter")
+        quantity, _, options, weights = generator._parse_combinations("1-$$bread|butter")
         assert quantity == (1, 2)
         assert options == ["bread", "butter"]
+        assert weights == [1.0, 1.0]
 
-        quantity, _, options = generator._parse_combinations("-1$$bread|butter")
+        quantity, _, options, weights = generator._parse_combinations("-1$$bread|butter")
         assert quantity == (0, 1)
         assert options == ["bread", "butter"]
+        assert weights == [1.0, 1.0]
 
-        quantity, _, options = generator._parse_combinations("2$$and$$bread|butter")
+        quantity, _, options, weights = generator._parse_combinations("2$$and$$bread|butter")
         assert quantity == (2, 2)
         assert options == ["bread", "butter"]
+        assert weights == [1.0, 1.0]
 
-        quantity, _, options = generator._parse_combinations("")
+        quantity, _, options, weights = generator._parse_combinations("")
         assert quantity == (1, 1)
         assert options == [""]
+        assert weights == [1.0]
+
+        quantity, _, options, weights = generator._parse_combinations("3::bread|2::butter")
+        assert quantity == (1, 1)
+        assert options == ["bread", "butter"]
+        assert weights == [3.0, 2.0]
+
+        quantity, _, options, weights = generator._parse_combinations("1.3::bread|butter")
+        assert quantity == (1, 1)
+        assert options == ["bread", "butter"]
+        assert weights == [1.3, 1.0]
+
+        quantity, _, options, weights = generator._parse_combinations("1-2$$2.5::bread|butter")
+        assert quantity == (1, 2)
+        assert options == ["bread", "butter"]
+        assert weights == [2.5, 1.0]
 
     def test_joiner(self, generator):
-        _, joiner, _ = generator._parse_combinations("bread|butter")
+        _, joiner, _, _ = generator._parse_combinations("bread|butter")
         assert joiner == constants.DEFAULT_COMBO_JOINER
 
-        _, joiner, _ = generator._parse_combinations("2$$bread|butter")
+        _, joiner, _, _ = generator._parse_combinations("2$$bread|butter")
         assert joiner == constants.DEFAULT_COMBO_JOINER
 
-        _, joiner, _ = generator._parse_combinations("2$$and$$bread|butter")
+        _, joiner, _, _ = generator._parse_combinations("2$$and$$bread|butter")
         assert joiner == "and"
 
-        _, joiner, _ = generator._parse_combinations("")
+        _, joiner, _, _ = generator._parse_combinations("")
         assert joiner == ","
 
-        _, joiner, _ = generator._parse_combinations("2$$|$$bread|butter")
+        _, joiner, _, _ = generator._parse_combinations("2$$|$$bread|butter")
         assert joiner == "|"
 
     def test_photographers(self, generator):
-        quantity, joiner, options = generator._parse_combinations("2-4$$|$$a|b|c")
+        quantity, joiner, options, weights = generator._parse_combinations("2-4$$|$$a|b|c")
 
 
 class TestGeneratorPrompt:
@@ -191,14 +263,14 @@ class TestGeneratorPrompt:
         assert prompt == ["I love butter"]
 
         prompt = generator.generate(2)
-        assert prompt == ["I love butter", "I love butter"]
+        assert prompt == ["I love bread", "I love butter"]
 
         prompt = generator.generate(4)
         assert prompt == [
             "I love bread",
             "I love bread",
             "I love butter",
-            "I love butter",
+            "I love bread",
         ]
 
 
@@ -215,7 +287,7 @@ class TestUnlinkSeedFromPrompt:
             generator._template = "I love {1-2$$red|green|blue}"
 
             prompt = generator.generate(5)
-            assert prompt == ['I love green , blue', 'I love green', 'I love blue', 'I love green', 'I love blue']
+            assert prompt == ['I love blue , red', 'I love blue , green', 'I love red', 'I love blue , red', 'I love green , blue']
             
 
         prev_prompt = None


### PR DESCRIPTION
# Weighted Variants

This PR introduces the ability to specify relative weights for all the variants in a dynamic prompt set.

This is purely additive, and should not modify the current behavior of existing prompts.

## Examples
For example, say we wanted to generate photos of balls. We want to make it generate 3x as many photos of blue balls than red balls. We can do this by giving "blue" a weight of 3.0, and leaving "red" at the default weight of 1.0:

```
photo of a {3::blue|red} ball
```

![weighted-prompt-balls](https://user-images.githubusercontent.com/2903742/209009605-f9fa2869-1004-46b1-a7b0-2529d2af5769.png)

Note that this is equivalent to doing the following in the current version:

```
photo of a {blue|blue|blue|red} ball
```

This new syntax is just a lot more succinct.

Here's another example: Generate photo portraits of men and women of different races, proportional to U.S. population demographics:

```
photo portrait of a {59::white|20::latino|13::black|8::asian} {man|woman}
```

![weighted-prompt-america](https://user-images.githubusercontent.com/2903742/209009631-90c70d28-2eea-4801-b36e-d5d8c342640e.png)

## Notes

- I went with `::` for the delimiter here, but of course that's arbitrary and it could be anything really.
- Added some new tests specifically for these weights.
- Added documentation for this new feature where relevant.
- Because I had to change `pick()` from `random.choice()` to `random.choices()`, the hard-coded random test values needed to be updated, resulting in a lot of changes to test files to get them passing again.
- I had to make a `pyproject.toml` file to get `pytest` to run. Including that here I guess?
- Added my editor config folder `.vscode` to `.gitignore`