### PR TITLE
Simplify install script

### DIFF
--- a/install.py
+++ b/install.py
@@ -1,63 +1,24 @@
 import logging
-import sys
 from pathlib import Path
 
-import launch  # from AUTOMATIC1111
+from dynamicprompts.utils import is_empty_line
 
 logger = logging.getLogger(__name__)
 
-if sys.version_info < (3, 8):
-    import importlib_metadata
-else:
-    import importlib.metadata as importlib_metadata
 
-
-def clean_package_name(s):
-    s = s.split("==")[0].strip()
-    s = s.split(">=")[0].strip()
-    s = s.split("<=")[0].strip()
-    s = s.split(">")[0].strip()
-    s = s.split("<")[0].strip()
-    s = s.split("~=")[0].strip()
-    s = s.split("!=")[0].strip()
-    s = s.split(" ")[0].strip()
-    s = s.split("[")[0].strip()
-
-    return s
-
-
-def ensure_installed(package):
-    isinstalled = launch.is_installed(package)
-    if not isinstalled:
-        launch.run_pip(f"install {package}", desc=f"{package}")
-
-
-def ensure_version(dependency, version):
-    package = clean_package_name(dependency)
-    isinstalled = launch.is_installed(package)
-    if isinstalled:
-        installed_version = importlib_metadata.version(package)
-        if installed_version == version:
-            return
-
-    launch.run_pip(f"install {dependency}=={version}", desc=f"{dependency}=={version}")
-
-
-def check_versions():
-    req_file = Path(__file__).parent / "requirements.txt"
-    for row in open(req_file):
-        splits = row.split("==")
-        try:
-            if len(splits) == 2:
-                dependency = splits[0].strip()
-                version = splits[1].strip()
-
-                ensure_version(dependency, version)
-            else:
-                package = row.strip()
-                ensure_installed(package)
-        except Exception as e:
-            logger.exception(e)
+def check_versions() -> None:
+    requirements = [
+        line
+        for line
+        in (Path(__file__).parent / "requirements.txt").read_text().splitlines()
+        if not is_empty_line(line)
+    ]
+    pip_command = f"install {' '.join(requirements)}"
+    try:
+        from launch import run_pip  # from AUTOMATIC1111
+        run_pip(pip_command, desc="sd-dynamic-prompts requirements.txt")
+    except Exception as e:
+        logger.exception(e)
 
 
 check_versions()


### PR DESCRIPTION
I don't see a reason to try and look for the given versions of the requirements; we could just tell `pip` to try and make sure those versions are available and that's that.

NB: I haven't tried this out yet, just throwing it out there. Let me know what you think, @adieyal!

Might help with #207.