### PR TITLE
Allow custom wildcard warp.

### DIFF
--- a/sd_dynamic_prompts/dynamic_prompting.py
+++ b/sd_dynamic_prompts/dynamic_prompting.py
@@ -367,6 +367,7 @@ class Script(scripts.Script):
         parser_config = ParserConfig(
             variant_start=opts.dp_parser_variant_start,
             variant_end=opts.dp_parser_variant_end,
+            wildcard_wrap=opts.dp_parser_wildcard_wrap,
         )
 
         fix_seed(p)

--- a/sd_dynamic_prompts/ui/settings.py
+++ b/sd_dynamic_prompts/ui/settings.py
@@ -43,3 +43,11 @@ def on_ui_settings():
             section=section,
         ),
     )
+    shared.opts.add_option(
+        key="dp_parser_wildcard_wrap",
+        info=shared.OptionInfo(
+            "__",
+            label="String to use as wrap for parser wildcard, .e.g __wildcard__",
+            section=section,
+        ),
+    )


### PR DESCRIPTION
# Motivation
Currently wildcard must be in the format of `__somewildcard__`.
When a lora or texual inversion using `__` in its name (which is valid and not so rare), the parser will fail.
To avoid this failure, users should be allowed to custom their own wildcard warp.

# What I did
A new setting for wildcard wrap is added:
<img width="372" alt="image" src="https://user-images.githubusercontent.com/82883326/220152771-3e66e559-e30a-4771-a4e0-ec25d6cb00bb.png">

# Result
Template prompt:
<img width="155" alt="image" src="https://user-images.githubusercontent.com/82883326/220151678-e4fc287e-4872-4a4d-99d0-c6b714a6e71e.png">

Generated prompt:
<img width="125" alt="image" src="https://user-images.githubusercontent.com/82883326/220153959-d6c6f8b4-204b-4727-bf76-a450c68a97fd.png">


# Problem
I didn't modify `Wildcards Manager`... Having no time to work on those code...
So it still using `__`:
<img width="707" alt="image" src="https://user-images.githubusercontent.com/82883326/220153354-22ed48bb-6b93-487c-9aad-bc8be6223e80.png">



