### PR TITLE
add combirandom (weighted random without replacement) variant picker

### DIFF
--- a/sd_dynamic_prompts/dynamic_prompting.py
+++ b/sd_dynamic_prompts/dynamic_prompting.py
@@ -171,6 +171,13 @@ class Script(scripts.Script):
                         elem_id="combinatorial-times",
                     )
 
+                with gr.Group():
+                    is_combirandom = gr.Checkbox(
+                        label="Combinatorial random generation",
+                        value=False,
+                        elem_id="is-combirandom",
+                    )
+
                 with gr.Accordion("Prompt Magic", open=False):
                     with gr.Group():
                         is_magic_prompt = gr.Checkbox(
@@ -304,6 +311,7 @@ class Script(scripts.Script):
             is_enabled,
             is_combinatorial,
             combinatorial_batches,
+            is_combirandom,
             is_magic_prompt,
             is_feeling_lucky,
             is_attention_grabber,
@@ -327,6 +335,7 @@ class Script(scripts.Script):
         is_enabled,
         is_combinatorial,
         combinatorial_batches,
+        is_combirandom,
         is_magic_prompt,
         is_feeling_lucky,
         is_attention_grabber,
@@ -388,6 +397,7 @@ class Script(scripts.Script):
                 )
                 .set_is_jinja_template(enable_jinja_templates)
                 .set_is_combinatorial(is_combinatorial, combinatorial_batches)
+                .set_is_combirandom(is_combirandom)
                 .set_is_magic_prompt(
                     is_magic_prompt,
                     magic_model=magic_model,

--- a/sd_dynamic_prompts/generator_builder.py
+++ b/sd_dynamic_prompts/generator_builder.py
@@ -10,6 +10,7 @@ from dynamicprompts.generators import (
     JinjaGenerator,
     PromptGenerator,
     RandomPromptGenerator,
+    CombiRandomPromptGenerator,
 )
 from dynamicprompts.generators.attentiongenerator import AttentionGenerator
 from dynamicprompts.generators.magicprompt import MagicPromptGenerator
@@ -33,6 +34,7 @@ class GeneratorBuilder:
         self._is_feeling_lucky = False
         self._is_jinja_template = False
         self._is_combinatorial = False
+        self._is_combirandom = False
         self._is_magic_prompt = False
         self._is_attention_grabber = False
 
@@ -58,6 +60,7 @@ class GeneratorBuilder:
             is_feeling_lucky: {self._is_feeling_lucky}
             enable_jinja_templates: {self._is_jinja_template}
             is_combinatorial: {self._is_combinatorial}
+            is_combirandom: {self._is_combirandom}
             is_magic_prompt: {self._is_magic_prompt}
             combinatorial_batches: {self._combinatorial_batches}
             magic_prompt_length: {self._magic_prompt_length}
@@ -96,6 +99,10 @@ class GeneratorBuilder:
     def set_is_combinatorial(self, is_combinatorial=True, combinatorial_batches=1):
         self._is_combinatorial = is_combinatorial
         self._combinatorial_batches = combinatorial_batches
+        return self
+  
+    def set_is_combirandom(self, is_combirandom=True):
+        self._is_combirandom = is_combirandom
         return self
 
     def set_is_magic_prompt(
@@ -182,6 +189,14 @@ class GeneratorBuilder:
             prompt_generator = BatchedCombinatorialPromptGenerator(
                 prompt_generator,
                 batches=self._combinatorial_batches,
+            )
+        elif self._is_combirandom:
+            prompt_generator = CombiRandomPromptGenerator(
+                self._wildcard_manager,
+                seed=self._seed,
+                parser_config=self._parser_config,
+                unlink_seed_from_prompt=self._unlink_seed_from_prompt,
+                ignore_whitespace=self._ignore_whitespace,
             )
         else:
             prompt_generator = RandomPromptGenerator(


### PR DESCRIPTION
This is an improvised enhancement regarding issue https://github.com/adieyal/sd-dynamic-prompts/issues/166.
this pull request requires https://github.com/adieyal/dynamicprompts/pull/52 to be merged to act.

Current combination token($$) works with random.choice, which is combination with replacement(repetition), which is useful for many situation. However in some situation, user do not want to repeat prompt, especially when someone is using combination to choose and mix multiple lora(i.e., {2$$lora:artistA:0.3|lora:artistB:0.3|…}.), because repetition of single lora can negatively affect result, and that was my case.

'combirandom' prompt generator/sampler introduced in https://github.com/adieyal/dynamicprompts/pull/52 tackles the problem, and this is for sd-dynamic-prompts ui implementation. some points to regard:

- combirandom checkbox will not work if 'Combinatorial generation' is checked. this commit is actually an in-house improvised solution for my personal workflow, and I don't have an idea how to merge in user interface smoothly. Ideas are welcomed.

This pull request is not meant to merged without consideration, rather this is proof of concept.