### PR TITLE
Fixed bug causing unwanted newlines in wildcards

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,4 @@
+- 2.8.7 Fixed bug causing unwanted newlines in wildcard files on Windows. See #270
 - 2.8.6 Added configurable batch size for Magic Prompts. Increasing the batch size can significantly improve prompt generation speed at the expense of slightly increases VRAM usage.
 - 2.8.5 Fixed infinite recursion in Gradio 3.22.1 - see [#316](https://github.com/adieyal/sd-dynamic-prompts/pull/316)
 - 2.8.4 Fixes ignore_whitespace for Jinja templates

--- a/sd_dynamic_prompts/dynamic_prompting.py
+++ b/sd_dynamic_prompts/dynamic_prompting.py
@@ -23,7 +23,7 @@ from sd_dynamic_prompts.ui.pnginfo_saver import PngInfoSaver
 from sd_dynamic_prompts.ui.prompt_writer import PromptWriter
 from sd_dynamic_prompts.ui.uicreation import UiCreation
 
-VERSION = "2.8.5"
+VERSION = "2.8.7"
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)

--- a/sd_dynamic_prompts/ui/wildcards_tab.py
+++ b/sd_dynamic_prompts/ui/wildcards_tab.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import json
 import logging
-import os
 import random
 import shutil
 
@@ -226,6 +225,6 @@ def save_file_callback(js):
             with path.open("w") as f:
                 contents = contents.splitlines()
                 for c in contents:
-                    f.write(c.strip() + os.linesep)
+                    f.write(c.strip() + "\n")
     except Exception as e:
         logger.exception(e)


### PR DESCRIPTION
See https://github.com/adieyal/sd-dynamic-prompts/issues/270.

According to the [docs](https://docs.python.org/3/library/os.html#os.linesep), os.linesep should not be used when writing in text mode. Thanks to @Vonpiper for spotting this.