### PR TITLE
Fixes #382

### DIFF
--- a/sd_dynamic_prompts/wildcards_tab.py
+++ b/sd_dynamic_prompts/wildcards_tab.py
@@ -280,6 +280,6 @@ def save_file_callback(event_str: str):
             wf.write_text(event["contents"].strip())
         else:
             raise Exception("Can't save non-text files")
-        return refresh_wildcards_callback()
+        return handle_load_wildcard({"name": event["wildcard"]["name"]})
     except Exception as e:
         logger.exception(e)


### PR DESCRIPTION
I replaced the refresh_wildcards with the load_wildcard command - I think that's okay because there's no real need to refresh the hierarchy when saving an individual file.