### PR TITLE
Make hires fix not crash with combinatorial processing

### DIFF
--- a/sd_dynamic_prompts/dynamic_prompting.py
+++ b/sd_dynamic_prompts/dynamic_prompting.py
@@ -487,3 +487,7 @@ class Script(scripts.Script):
 
         p.prompt_for_display = original_prompt
         p.prompt = original_prompt
+
+        if getattr(p, "enable_hr", False):  # Hires fix?
+            p.all_hr_prompts = all_prompts
+            p.all_hr_negative_prompts = all_negative_prompts


### PR DESCRIPTION
I'm not sure at all this is the right fix, as my eyes kinda glaze over trying to figure out what the difference between hr_prompt, hr_prompts, all_hr_prompts etc. in the webui is.

However, with this, hires fix doesn't _crash_. 

Refs https://github.com/adieyal/sd-dynamic-prompts/issues/474 (won't say it fixes it at this point).

The webui commit that caused this regression is https://github.com/AUTOMATIC1111/stable-diffusion-webui/commit/ff0e17174f8d93a71fdd5a4a80a4629bbf97f822