### PR TITLE
slightly better hires fix.

### DIFF
--- a/sd_dynamic_prompts/dynamic_prompting.py
+++ b/sd_dynamic_prompts/dynamic_prompting.py
@@ -75,19 +75,15 @@ def get_hr_prompts(p) -> Tuple[str, str]:
 
 
 def check_hr_overwrite(p) -> Tuple[bool, bool]:
+    '''The return values indicate if all_hr_prompts or all_hr_negative_prompts respectively should be
+    overwritten'''
     if not getattr(p, "enable_hr", False):
         return False, False
 
     prompt, negative_prompt = get_prompts(p)
     hr_prompt, hr_negative = get_hr_prompts(p)
 
-    hr_prompt_overwrite = False
-    hr_negative_overwrite = False
-    if prompt == hr_prompt:
-        hr_prompt_overwrite = True
-    if negative_prompt == hr_negative:
-        hr_negative_overwrite = True
-    return hr_prompt_overwrite, hr_negative_overwrite
+    return (prompt == hr_prompt), (negative_prompt == hr_negative)
 
 
 device = devices.device

--- a/sd_dynamic_prompts/dynamic_prompting.py
+++ b/sd_dynamic_prompts/dynamic_prompting.py
@@ -67,16 +67,20 @@ def get_prompts(p):
     return original_prompt, original_negative_prompt
 
 
-def get_hr_prompts(p) -> Tuple[str, str]:
+def get_hr_prompts(p) -> tuple[str, str]:
     hr_prompt = p.all_hr_prompts[0] if len(p.all_hr_prompts) > 0 else p.hr_prompt
-    hr_negative = p.all_hr_negative_prompts[0] if len(p.all_hr_negative_prompts) > 0 else p.hr_negative_prompt
+    hr_negative = (
+        p.all_hr_negative_prompts[0]
+        if len(p.all_hr_negative_prompts) > 0
+        else p.hr_negative_prompt
+    )
 
     return hr_prompt, hr_negative
 
 
-def check_hr_overwrite(p) -> Tuple[bool, bool]:
-    '''The return values indicate if all_hr_prompts or all_hr_negative_prompts respectively should be
-    overwritten'''
+def check_hr_overwrite(p) -> tuple[bool, bool]:
+    """The return values indicate if all_hr_prompts or all_hr_negative_prompts respectively should be
+    overwritten"""
     if not getattr(p, "enable_hr", False):
         return False, False
 
@@ -412,7 +416,9 @@ class Script(scripts.Script):
         fix_seed(p)
 
         original_prompt, original_negative_prompt = get_prompts(p)
-        hr_prompt_overwrite, hr_negative_overwrite = check_hr_overwrite(p) # must be before p.prompt,negative,hr_prompt are updated
+        hr_prompt_overwrite, hr_negative_overwrite = check_hr_overwrite(
+            p
+        ) # must be before p.prompt,negative,hr_prompt are updated
         original_seed = p.seed
         num_images = p.n_iter * p.batch_size
 

--- a/sd_dynamic_prompts/dynamic_prompting.py
+++ b/sd_dynamic_prompts/dynamic_prompting.py
@@ -415,10 +415,9 @@ class Script(scripts.Script):
 
         fix_seed(p)
 
+        # must be before p.prompt/p.hr_prompt are updated
         original_prompt, original_negative_prompt = get_prompts(p)
-        hr_prompt_overwrite, hr_negative_overwrite = check_hr_overwrite(
-            p
-        ) # must be before p.prompt,negative,hr_prompt are updated
+        hr_prompt_overwrite, hr_negative_overwrite = check_hr_overwrite(p)
         original_seed = p.seed
         num_images = p.n_iter * p.batch_size
 


### PR DESCRIPTION
The idea is if the hr params match the prompt params, overwrite. But otherwise force the hr prompt into a condition that won't blow up under combinatorial by expanding the first or only hr prompt into all slots as needed.

Where this goes wrong is if an extension further up stack from us fills in all_hr_prompts/all_hr_negative_prompts and we ignore the variations in other slots. Not sure the best way to address that at this time.