### PR TITLE
install.py: try to patch sys.path if the extension is not there?

### DIFF
--- a/install.py
+++ b/install.py
@@ -1,4 +1,14 @@
 if __name__ == "__main__":
-    from sd_dynamic_prompts.version_tools import install_requirements
+    try:
+        from sd_dynamic_prompts.version_tools import install_requirements
+    except ImportError:
+        # This patching shouldn't be necessary, but who knows... See issue #486.
+        import os
+        import sys
+
+        extension_dir = os.path.dirname(os.path.abspath(__file__))
+        if extension_dir not in sys.path:
+            sys.path.insert(0, extension_dir)
+        from sd_dynamic_prompts.version_tools import install_requirements
 
     install_requirements()


### PR DESCRIPTION
Fixes #486 (though I don't understand why this is needed...).