### PR TITLE
combinatorial: cross product positive and negative prompt combinations

### DIFF
--- a/sd_dynamic_prompts/helpers.py
+++ b/sd_dynamic_prompts/helpers.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 import logging
-from pathlib import Path
 from itertools import product
+from pathlib import Path
 
 from dynamicprompts.generators.promptgenerator import PromptGenerator
 
@@ -101,4 +101,4 @@ def generate_prompts(
         seeds=negative_seeds,
     ) or [""]
 
-    return list(zip(*product(all_prompts, all_negative_prompts)))
+    return list(zip(*product(all_prompts, all_negative_prompts), strict=True))

--- a/sd_dynamic_prompts/helpers.py
+++ b/sd_dynamic_prompts/helpers.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
+from itertools import product
 
 from dynamicprompts.generators.promptgenerator import PromptGenerator
 
@@ -100,9 +101,4 @@ def generate_prompts(
         seeds=negative_seeds,
     ) or [""]
 
-    if len(all_negative_prompts) < len(all_prompts):
-        factor = len(all_prompts) // len(all_negative_prompts) + 1
-        all_negative_prompts = all_negative_prompts * factor
-    all_negative_prompts = all_negative_prompts[: len(all_prompts)]
-
-    return all_prompts, all_negative_prompts
+    return list(zip(*product(all_prompts, all_negative_prompts)))


### PR DESCRIPTION
Currently, cross-production of positive and negative prompts aren't performed well ~(well, technically, the cross-product for them is not performed at all)~.

<details>
  <summary>First example</summary>

| Prompt | Negative prompt |
| ------ | --------------- |
| cat    | {blurry\|ugly}  |

These prompts are converted into:
| Prompt | Negative prompt |
| ------ | --------------- |
| cat    | blurry          |

e.g. only first negative prompt combination is used.

</details>

<details>
  <summary>Second example</summary>

| Prompt          | Negative prompt |
| --------------- | --------------- |
| {1\|2\|3\|4\|5} | {7\|8}          |

These prompts are converted into:
| Prompt | Negative prompt |
| ------ | --------------- |
| 1      | 7               |
| 2      | 8               |
| 3      | 7               |
| 4      | 8               |
| 5      | 7               |

As it can be seen, there can be seen only 5 combinations out of all 10 combinations.

</details>

---

So, this PR introduces the cross-production of positive and negative prompt combinations.

<details>
  <summary>First example (fixed)</summary>

Input:
| Prompt | Negative prompt |
| ------ | --------------- |
| cat    | {blurry\|ugly}  |

Output:
| Prompt | Negative prompt |
| ------ | --------------- |
| cat    | blurry          |
| cat    | ugly            |
  
</details>

<details>
  <summary>Second example (fixed)</summary>

Input:
| Prompt          | Negative prompt |
| --------------- | --------------- |
| {1\|2\|3\|4\|5} | {7\|8}          |

Output:
| Prompt | Negative prompt |
| ------ | --------------- |
| 1      | 7               |
| 1      | 8               |
| 2      | 7               |
| 2      | 8               |
| 3      | 7               |
| 3      | 8               |
| 4      | 7               |
| 4      | 8               |
| 5      | 7               |
| 5      | 8               |
  
</details>