### PR TITLE
fix for pnginfo_saver, when extension is disabled, #177

### DIFF
--- a/sd_dynamic_prompts/dynamic_prompting.py
+++ b/sd_dynamic_prompts/dynamic_prompting.py
@@ -368,14 +368,15 @@ class Script(scripts.Script):
         magic_model: str | None,
         magic_blocklist_regex: str | None,
     ):
+        self._pnginfo_saver.enabled = opts.dp_write_raw_template
+        self._prompt_writer.enabled = opts.dp_write_prompts_to_file
+
         if not is_enabled:
             logger.debug("Dynamic prompts disabled - exiting")
             return p
 
         ignore_whitespace = opts.dp_ignore_whitespace
 
-        self._pnginfo_saver.enabled = opts.dp_write_raw_template
-        self._prompt_writer.enabled = opts.dp_write_prompts_to_file
         self._limit_jinja_prompts = opts.dp_limit_jinja_prompts
         self._auto_purge_cache = opts.dp_auto_purge_cache
         self._wildcard_manager.dedup_wildcards = not opts.dp_wildcard_manager_no_dedupe


### PR DESCRIPTION
There are cases when a `Template` and `Negative Template` line are added to the end of the pnginfo of a file. This breaks extensions that use the SendTo functionality (like PNG Info inside a1111 or the Image Browser extension).

This happens when Dynamic Prompts are installed, but not enabled.

The reason for this is, that the default here is True:

```
class PngInfoSaver:
    def __init__(self):
        self._enabled = True

```
But the following code exits the function before it can be set to its current False value:

```
        if not is_enabled:
            logger.debug("Dynamic prompts disabled - exiting")
            return p

        ignore_whitespace = opts.dp_ignore_whitespace

        self._pnginfo_saver.enabled = opts.dp_write_raw_template
        self._prompt_writer.enabled = opts.dp_write_prompts_to_file

``` 
This PR fixes that.