### PR TITLE
Use orthodox method for pnginfo

### DIFF
--- a/sd_dynamic_prompts/callbacks.py
+++ b/sd_dynamic_prompts/callbacks.py
@@ -9,37 +9,12 @@ from modules import script_callbacks
 from modules.generation_parameters_copypaste import parse_generation_parameters
 from modules.script_callbacks import ImageSaveParams
 
-from sd_dynamic_prompts.pnginfo_saver import (
-    PngInfoSaver,
-    PromptTemplates,
-    strip_template_info,
-)
+from sd_dynamic_prompts.pnginfo_saver import strip_template_info
 from sd_dynamic_prompts.prompt_writer import PromptWriter
 from sd_dynamic_prompts.settings import on_ui_settings
 from sd_dynamic_prompts.wildcards_tab import initialize as initialize_wildcards_tab
 
 logger = logging.getLogger(__name__)
-
-
-def register_pnginfo_saver(pnginfo_saver: PngInfoSaver) -> None:
-    def on_save(image_save_params: ImageSaveParams) -> None:
-        try:
-            if image_save_params.p:
-                png_info = image_save_params.pnginfo["parameters"]
-                image_prompts = PromptTemplates(
-                    positive_template=image_save_params.p.prompt,
-                    negative_template=image_save_params.p.negative_prompt,
-                )
-
-                updated_png_info = pnginfo_saver.update_pnginfo(
-                    png_info,
-                    image_prompts,
-                )
-                image_save_params.pnginfo["parameters"] = updated_png_info
-        except Exception:
-            logger.exception("Error save prompt file")
-
-    script_callbacks.on_before_image_saved(on_save)
 
 
 def register_prompt_writer(prompt_writer: PromptWriter) -> None:

--- a/sd_dynamic_prompts/dynamic_prompting.py
+++ b/sd_dynamic_prompts/dynamic_prompting.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import json
 import logging
 import math
 from functools import lru_cache
@@ -13,7 +12,6 @@ import torch
 from dynamicprompts.generators.promptgenerator import GeneratorException
 from dynamicprompts.parser.parse import ParserConfig
 from dynamicprompts.wildcards import WildcardManager
-from modules import generation_parameters_copypaste
 from modules.processing import fix_seed
 from modules.shared import opts
 
@@ -83,17 +81,6 @@ def get_magic_prompt_device() -> torch.device:
     if device.type == "cuda" and not device.index:
         device = torch.device("cuda:0")
     return device
-
-
-def ensure_quoted_parameter(parameter: str) -> str | None:
-    """
-    if parameter is empty, return None
-    else quote parameter if it will not be automatically quoted by webui
-    """
-    if parameter:
-        if parameter == generation_parameters_copypaste.quote(parameter):
-            parameter = json.dumps(parameter, ensure_ascii=False)
-        return parameter
 
 
 class Script(scripts.Script):
@@ -530,12 +517,8 @@ class Script(scripts.Script):
         )
 
         if opts.dp_write_raw_template:
-            p.extra_generation_params["Template"] = ensure_quoted_parameter(
-                original_prompt,
-            )
-            p.extra_generation_params["Negative Template"] = ensure_quoted_parameter(
-                original_negative_prompt,
-            )
+            p.extra_generation_params["Template"] = original_prompt
+            p.extra_generation_params["Negative Template"] = original_negative_prompt
 
         p.all_prompts = all_prompts
         p.all_negative_prompts = all_negative_prompts

--- a/sd_dynamic_prompts/dynamic_prompting.py
+++ b/sd_dynamic_prompts/dynamic_prompting.py
@@ -32,7 +32,6 @@ from sd_dynamic_prompts.paths import (
     get_magicprompt_models_txt_path,
     get_wildcard_dir,
 )
-from sd_dynamic_prompts.pnginfo_saver import PngInfoSaver
 from sd_dynamic_prompts.prompt_writer import PromptWriter
 
 VERSION = __version__
@@ -109,7 +108,6 @@ class Script(scripts.Script):
 
         # When the Reload UI button in the settings tab is pressed, the script is loaded twice again
         # Therefore we only register callbacks every second time the script is loaded
-        self._pnginfo_saver = PngInfoSaver()
         self._prompt_writer = PromptWriter()
         self._wildcard_manager = WildcardManager(get_wildcard_dir())
 

--- a/sd_dynamic_prompts/dynamic_prompting.py
+++ b/sd_dynamic_prompts/dynamic_prompting.py
@@ -85,15 +85,15 @@ def get_magic_prompt_device() -> torch.device:
     return device
 
 
-def requote_prompt(prompt: str) -> str | None:
-    # if prompt is empty, return None
-    # if prompt will not be auto quoted by webui and can effected by stripping, we need to quote it ourselves
-    if prompt:
-        if prompt != prompt.strip() and prompt == generation_parameters_copypaste.quote(
-            prompt,
-        ):
-            prompt = json.dumps(prompt, ensure_ascii=False)
-        return prompt
+def ensure_quoted_parameter(parameter: str) -> str | None:
+    """
+    if parameter is empty, return None
+    else quote parameter if it will not be automatically quoted by webui
+    """
+    if parameter:
+        if parameter == generation_parameters_copypaste.quote(parameter):
+            parameter = json.dumps(parameter, ensure_ascii=False)
+        return parameter
 
 
 class Script(scripts.Script):
@@ -530,8 +530,10 @@ class Script(scripts.Script):
         )
 
         if opts.dp_write_raw_template:
-            p.extra_generation_params["Template"] = requote_prompt(original_prompt)
-            p.extra_generation_params["Negative Template"] = requote_prompt(
+            p.extra_generation_params["Template"] = ensure_quoted_parameter(
+                original_prompt,
+            )
+            p.extra_generation_params["Negative Template"] = ensure_quoted_parameter(
                 original_negative_prompt,
             )
 

--- a/sd_dynamic_prompts/pnginfo_saver.py
+++ b/sd_dynamic_prompts/pnginfo_saver.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-from dataclasses import dataclass
 from typing import Any
 
 logger = logging.getLogger(__name__)
@@ -31,36 +30,3 @@ def strip_template_info(parameters: dict[str, Any]) -> None:
             parameters["Negative prompt"] = (
                 parameters["Negative prompt"].split(split_by)[0].strip()
             )
-
-
-@dataclass
-class PromptTemplates:
-    positive_template: str
-    negative_template: str
-
-
-class PngInfoSaver:
-    def __init__(self):
-        self._enabled = True
-
-    @property
-    def enabled(self) -> bool:
-        return self._enabled
-
-    @enabled.setter
-    def enabled(self, enabled: bool) -> None:
-        self._enabled = enabled
-
-    def update_pnginfo(self, parameters: str, prompt_templates: PromptTemplates) -> str:
-        if not self._enabled:
-            return parameters
-
-        if prompt_templates.positive_template:
-            parameters += f"\n{TEMPLATE_LABEL}: {prompt_templates.positive_template}"
-
-        if prompt_templates.negative_template:
-            parameters += (
-                f"\n{NEGATIVE_TEMPLATE_LABEL}: {prompt_templates.negative_template}"
-            )
-
-        return parameters

--- a/tests/prompts/ui/test_pnginfo_saver.py
+++ b/tests/prompts/ui/test_pnginfo_saver.py
@@ -2,11 +2,7 @@ from typing import Any
 
 import pytest
 
-from sd_dynamic_prompts.pnginfo_saver import (
-    PngInfoSaver,
-    PromptTemplates,
-    strip_template_info,
-)
+from sd_dynamic_prompts.pnginfo_saver import strip_template_info
 
 
 @pytest.fixture
@@ -18,32 +14,6 @@ def basic_parameters():
         "Hires resize-1": 0,
         "Hires resize-2": 0,
     }
-
-
-def test_update_pnginfo() -> None:
-    png_info_saver = PngInfoSaver()
-    image_prompts = PromptTemplates("Template", "Negative Template")
-    parameters = "Parameters"
-    updated_parameters = png_info_saver.update_pnginfo(parameters, image_prompts)
-
-    assert (
-        updated_parameters
-        == f"Parameters\nTemplate: {image_prompts.positive_template}\nNegative Template: {image_prompts.negative_template}"
-    )
-
-    image_prompts.positive_template = ""
-    updated_parameters = png_info_saver.update_pnginfo(parameters, image_prompts)
-    assert (
-        updated_parameters
-        == f"Parameters\nNegative Template: {image_prompts.negative_template}"
-    )
-
-    image_prompts.positive_template = "Positive Template"
-    image_prompts.negative_template = ""
-    updated_parameters = png_info_saver.update_pnginfo(parameters, image_prompts)
-    assert (
-        updated_parameters == f"Parameters\nTemplate: {image_prompts.positive_template}"
-    )
 
 
 BASIC_PARAMETERS = "Steps: 35, Sampler: Heun, CFG scale: 9, Seed: 77777, Size: 640x640, Model hash: d8691b4d16"


### PR DESCRIPTION
over at webui we recive a bug reort
[Bug]: Dynamic Prompt Metadata in blocks "Read Generation Parameters from Prompt" if extension is missing/disabled 
 https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/14201#issuecomment-1839119678

as far as I can tell this is caused by sd-dynamic-prompts using an unorthodox method of writing the pnginfo
when `opts.dp_write_raw_template` is enabled

wrining pnginfo in newline causing the webui pnginfo parser webui break as I believe you are aware, base on 
do you have implemented a call back to remove the extra pnginfo added by this extension
https://github.com/adieyal/sd-dynamic-prompts/blob/aedb3e4b91026351981f8412eb9e2e74167fdcff/sd_dynamic_prompts/pnginfo_saver.py#L45

in other words if one does not have dynamic-prompts, the pnginfo syntax is invalid

this PR changes the way how pnginfo in written
I essentially commented out the code that you use to write pnginfo and use the "orthodox" method of writting pnginfo
I chose to comment out and not remove the code because I don't know if there's other components that relies on those info writing classes
the `strip_template_info` is still enabled for compatibility with existing images



> as far as I'm aware
`Template`  and `Negative Template` are purely informational and only is viewed directly by the user and not by the script in any way

there's one practical downside of my implementation
the information displayed in the PNG info tab looks far less tidy as it is all cramped in one place
but I believe compatibility should be more important than aesthetics
