### PR TITLE
Fix metadata template issue when using Adetailer

### DIFF
--- a/sd_dynamic_prompts/dynamic_prompting.py
+++ b/sd_dynamic_prompts/dynamic_prompting.py
@@ -518,9 +518,9 @@ class Script(scripts.Script):
 
         if opts.dp_write_raw_template:
             params = p.extra_generation_params
-            if original_prompt:
+            if original_prompt and "Template" not in params:
                 params["Template"] = original_prompt
-            if original_negative_prompt:
+            if original_negative_prompt and "Negative Template" not in params:
                 params["Negative Template"] = original_negative_prompt
 
         p.all_prompts = all_prompts


### PR DESCRIPTION
This PR fixes a bug with how the prompt template is saved when using Adetailer: https://github.com/adieyal/sd-dynamic-prompts/issues/703

I'm not sure why Adetailer does this, but after it processes an image, it calls the process() function of dynamic-prompts a second time and, during this second execution, dynamic-prompts overwrites its template metadata with a prompt value that no longer contains template information.

So this PR just makes sure not to overwrite the template metadata after it's written correctly the first time.