### PR TITLE
Run attention generator tests without spaCy

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,8 @@ jobs:
         with:
           python-version: "3.10"
           cache: "pip"
+      - name: Install CPU Torch
+        run: pip3 install torch torchaudio --index-url https://download.pytorch.org/whl/cpu
       - name: Install dependencies
         run: |
           python -m pip install pytest-cov

--- a/tests/prompts/test_attention_generator.py
+++ b/tests/prompts/test_attention_generator.py
@@ -1,11 +1,7 @@
-import pytest
-
 from sd_dynamic_prompts.attention_generator import SpecialSyntaxAwareAttentionGenerator
 
 
-@pytest.mark.slow
 def test_default_generator():
-    pytest.importorskip("spacy")
     generator = SpecialSyntaxAwareAttentionGenerator()
     for prompt in generator.generate(
         "purple cat singing opera, artistic, painting "


### PR DESCRIPTION
dynamicprompts v0.26.0+ (https://github.com/adieyal/dynamicprompts/pull/85) doesn't require spaCy for attention, so we can test it in CI here too.