### PR TITLE
fix: avoid Template overwrite when re-process and add new infotext

### DIFF
--- a/sd_dynamic_prompts/dynamic_prompting.py
+++ b/sd_dynamic_prompts/dynamic_prompting.py
@@ -427,11 +427,6 @@ class Script(scripts.Script):
             self._wildcard_manager.clear_cache()
 
         try:
-            self._wildcard_manager.clear_used_collection()
-        except Exception as e:
-            pass
-
-        try:
             logger.debug("Creating generator")
 
             generator_builder = (
@@ -574,10 +569,11 @@ class Script(scripts.Script):
             for _path in self._wildcard_manager.used_collection_dict().keys():
                 _key = str(_path.relative_to(self._wildcard_manager.path).as_posix())
                 _files[_key] = hashes_auto_v2(_path, str(_path.as_posix()))[:10]
-            params[key] = _files
-            print(_files)
 
-            dump_cache()
+            if len(_files):
+                params[key] = _files
+                print(_files)
+                dump_cache()
         except e:
             print(e)
             pass
@@ -634,6 +630,11 @@ class Script(scripts.Script):
 
             infotexts.pop(index_of_first_image-1)
             infotexts.insert(index_of_first_image-1, text)
+
+        try:
+            self._wildcard_manager.clear_used_collection()
+        except Exception as e:
+            pass
 
 
 def hashes_auto_v2(filename, title, use_addnet_hash=False):

--- a/sd_dynamic_prompts/dynamic_prompting.py
+++ b/sd_dynamic_prompts/dynamic_prompting.py
@@ -427,6 +427,11 @@ class Script(scripts.Script):
             self._wildcard_manager.clear_cache()
 
         try:
+            self._wildcard_manager.clear_used_collection()
+        except Exception as e:
+            pass
+
+        try:
             logger.debug("Creating generator")
 
             generator_builder = (

--- a/sd_dynamic_prompts/dynamic_prompting.py
+++ b/sd_dynamic_prompts/dynamic_prompting.py
@@ -98,7 +98,7 @@ class Script(scripts.Script):
         self._prompt_writer = PromptWriter()
         self._wildcard_manager = WildcardManager(get_wildcard_dir())
 
-        if loaded_count % 2 == 0:
+        if loaded_count % 2:
             return
 
         callbacks.register_prompt_writer(self._prompt_writer)

--- a/sd_dynamic_prompts/dynamic_prompting.py
+++ b/sd_dynamic_prompts/dynamic_prompting.py
@@ -517,10 +517,22 @@ class Script(scripts.Script):
 
         if opts.dp_write_raw_template:
             params = p.extra_generation_params
-            if original_prompt:
-                params["Template"] = original_prompt
-            if original_negative_prompt:
-                params["Negative Template"] = original_negative_prompt
+
+            first_time_only = params.get("Dynamic Prompts") is None
+
+            params["Dynamic Prompts"] = {
+                "use_fixed_seed": use_fixed_seed,
+                "unlink_seed_from_prompt": unlink_seed_from_prompt,
+                "enable_jinja_templates": enable_jinja_templates,
+            }
+
+            if first_time_only:
+                def _lazy_params(k1: str, v1, v2):
+                    if k1 not in params and v1 != v2:
+                        params[k1] = v1
+
+                _lazy_params("Template", original_prompt, all_prompts[0])
+                _lazy_params("Negative Template", original_negative_prompt, all_negative_prompts[0])
 
         p.all_prompts = all_prompts
         p.all_negative_prompts = all_negative_prompts

--- a/sd_dynamic_prompts/wildcards_tab.py
+++ b/sd_dynamic_prompts/wildcards_tab.py
@@ -74,17 +74,12 @@ def on_ui_tabs():
         <li>Use the wildcard in your script by typing the name of the file or copying the text from the Wildcards file text box.</li>
         <li>You can also add your own wildcard files to the {wildcard_manager.path} folder.</li>
     </ol>
+    <style>#sddp-wildcard-tree {{ max-height: max(70vh, 900px); overflow-y: auto !important; }}</style>
     """
 
     with gr.Blocks() as wildcards_tab:
         with gr.Row():
             with gr.Column():
-                gr.Textbox(
-                    placeholder="Search in wildcard names...",
-                    elem_id=make_element_id("wildcard-search"),
-                    label="",
-                )
-                gr.HTML("Loading...", elem_id=make_element_id("wildcard-tree"))
                 with gr.Accordion("Help", open=False):
                     gr.HTML(help_html)
                 with gr.Accordion("Collection actions", open=False):
@@ -111,6 +106,12 @@ def on_ui_tabs():
                             "Delete all wildcards",
                             elem_id=make_element_id("wildcard-delete-tree-button"),
                         )
+                gr.Textbox(
+                    placeholder="Search in wildcard names...",
+                    elem_id=make_element_id("wildcard-search"),
+                    label="",
+                )
+                gr.HTML("Loading...", elem_id=make_element_id("wildcard-tree"))
             with gr.Column():
                 gr.Textbox(
                     "",
@@ -127,7 +128,7 @@ def on_ui_tabs():
                 )
                 save_button = gr.Button(
                     "Save wildcards",
-                    scale=1,
+                    # scale=1,
                     elem_id=make_element_id("wildcard-save-button"),
                 )
 
@@ -180,7 +181,6 @@ def on_ui_tabs():
             inputs=[overwrite_checkbox, collection_dropdown],
             outputs=[server_to_client_message_textbox],
         )
-
     return ((wildcards_tab, "Wildcards Manager", "sddp-wildcard-manager"),)
 
 


### PR DESCRIPTION
- if install `ADetailer`, the process will run again, it makes `Template` getting overwrite
- add `Template Generated Grid`, this make can save generated prompts in grid



https://github.com/bluelovers/sd-webui-pnginfo-beautify?tab=readme-ov-file#decode

![image](https://github.com/adieyal/sd-dynamic-prompts/assets/167966/69e7da78-d995-4858-9fb5-2ad7f32a6c99)
